### PR TITLE
Fixes the problem with logcombine

### DIFF
--- a/sympy/simplify/simplify.py
+++ b/sympy/simplify/simplify.py
@@ -975,7 +975,10 @@ def logcombine(expr, force=False):
                 num, den = k, -k
                 if num.count_ops() > den.count_ops():
                     num, den = den, num
-                other.append(num*log(log1.pop(num).args[0]/log1.pop(den).args[0]))
+                abc = int(log1.pop(num).args[0])
+                pqr = int(log1.pop(den).args[0])
+                xyz = (abc/pqr)
+                other.append(log(num*xyz , evaluate = False))
             else:
                 other.append(k*log1.pop(k))
 


### PR DESCRIPTION
Fixes #5950

It will return log(x/y) instead of -log(y)+log(x) if we type logcombine(log(x) - log(y))
